### PR TITLE
Person notes

### DIFF
--- a/Ceaseless.xcodeproj/project.pbxproj
+++ b/Ceaseless.xcodeproj/project.pbxproj
@@ -458,11 +458,11 @@
 				TargetAttributes = {
 					42F3AE171AA4DD7F003A88F5 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = 28DYBASY7W;
+						DevelopmentTeam = 98FUBN4YVB;
 					};
 					42F3AE361AA4DD80003A88F5 = {
 						CreatedOnToolsVersion = 6.1.1;
-						DevelopmentTeam = 28DYBASY7W;
+						DevelopmentTeam = 98FUBN4YVB;
 						TestTargetID = 42F3AE171AA4DD7F003A88F5;
 					};
 				};

--- a/Ceaseless/Base.lproj/Main.storyboard
+++ b/Ceaseless/Base.lproj/Main.storyboard
@@ -115,7 +115,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r8K-Y6-IDZ" userLabel="leftFiller">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r8K-Y6-IDZ" userLabel="leftFiller">
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="Z91-wn-3pZ"/>
@@ -126,7 +126,7 @@
                                                 </mask>
                                             </variation>
                                         </view>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j74-k2-2nG" userLabel="rightFiller">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j74-k2-2nG" userLabel="rightFiller">
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="vGZ-j1-nPJ"/>

--- a/Ceaseless/Base.lproj/Main.storyboard
+++ b/Ceaseless/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="mXJ-JJ-gyu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="mXJ-JJ-gyu">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -116,6 +116,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r8K-Y6-IDZ" userLabel="leftFiller">
+                                            <rect key="frame" x="8" y="0.0" width="0.0" height="28"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="Z91-wn-3pZ"/>
@@ -127,6 +128,7 @@
                                             </variation>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j74-k2-2nG" userLabel="rightFiller">
+                                            <rect key="frame" x="592" y="0.0" width="0.0" height="28"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="vGZ-j1-nPJ"/>
@@ -377,7 +379,6 @@
                                     </constraints>
                                     <variation key="default">
                                         <mask key="constraints">
-                                            <exclude reference="bI4-AK-ncr"/>
                                             <exclude reference="tz8-Z6-byg"/>
                                             <exclude reference="AXX-67-Vrn"/>
                                             <exclude reference="F02-Ga-PFb"/>
@@ -386,6 +387,7 @@
                                             <exclude reference="s0D-Ux-gof"/>
                                             <exclude reference="s9N-CS-oT6"/>
                                             <exclude reference="sFR-rj-FsS"/>
+                                            <exclude reference="bI4-AK-ncr"/>
                                         </mask>
                                     </variation>
                                 </view>

--- a/Ceaseless/ContactsListsViewController.m
+++ b/Ceaseless/ContactsListsViewController.m
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, ContactsListsPredicateScope)
 	self.searchController.searchResultsUpdater = self;
 	self.searchController.dimsBackgroundDuringPresentation = NO;
 	self.searchController.searchBar.barTintColor = UIColorFromRGBWithAlpha(0x00012f , 0.4);
-	self.searchController.searchBar.tintColor = [UIColor whiteColor];
+	self.searchController.searchBar.tintColor = [UIColor lightGrayColor];
 	self.searchController.searchBar.scopeButtonTitles = @[NSLocalizedString(@"",@"")];
 	self.searchController.searchBar.delegate = self;
 		//		// Hide the search bar until user scrolls up

--- a/Ceaseless/PrayerJournalViewController.m
+++ b/Ceaseless/PrayerJournalViewController.m
@@ -76,8 +76,8 @@ typedef NS_ENUM(NSInteger, PrayerJournalSearchScope)
 	self.searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
 	self.searchController.searchResultsUpdater = self;
 	self.searchController.dimsBackgroundDuringPresentation = NO;
-	self.searchController.searchBar.barTintColor = UIColorFromRGBWithAlpha(0x24292f , 0.4);
-	self.searchController.searchBar.tintColor = [UIColor whiteColor];
+	self.searchController.searchBar.barTintColor = UIColorFromRGBWithAlpha(0x00012f , 0.4);
+	self.searchController.searchBar.tintColor = [UIColor lightGrayColor];
 	self.searchController.searchBar.scopeButtonTitles = @[NSLocalizedString(@"Note text",@"Note text"),
 														  NSLocalizedString(@"Person Tagged",@"Person Tagged")];
 	self.searchController.searchBar.delegate = self;


### PR DESCRIPTION
added search by person tagged to Prayer Journal

there are a couple enhancements that could be made:
1.  currently searches on first or last name with a BEGINSWITH, would work more like searching names if it searched BEGINSWITH (concatenated First and Last) or BEGINSWITH Last or maybe there should be an intermediate step where a person can be selected and then all their notes show up

2.  The tintColor of the words (Cancel, Note text, Person Tagged would be better white, but the cursor takes that tintColor too so it doesn't show up if tintColor is white.  I'm sure there is a way to dig down into the views and set the cursor to a different color, just not an easy fix.  