### PR TITLE
Internal ab change no sync

### DIFF
--- a/Ceaseless/AppConstants.h
+++ b/Ceaseless/AppConstants.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @interface AppConstants : NSObject
+    FOUNDATION_EXPORT NSString *const kLocalInstallationId;
     FOUNDATION_EXPORT NSString *const kCeaselessAppstoreAppId;
     FOUNDATION_EXPORT NSString *const kDeveloperMode;
     FOUNDATION_EXPORT NSString *const kDailyPersonCount;

--- a/Ceaseless/AppConstants.m
+++ b/Ceaseless/AppConstants.m
@@ -10,7 +10,11 @@
 
 @implementation AppConstants
 
+    // id in the app store
     NSString *const kCeaselessAppstoreAppId = @"973610764";
+
+    // user default key for storing the installation id
+    NSString *const kLocalInstallationId = @"localInstallationId";
 
     // this is the user default key for whether or not
     // the app is in developer mode

--- a/Ceaseless/AppUtils.h
+++ b/Ceaseless/AppUtils.h
@@ -26,6 +26,7 @@ blue:((float)(rgbValue & 0xFF))/255.0 alpha:a]
 + (ABAddressBookRef) getAddressBookRef;
 + (void) bounceView: (UIView *) viewToAnimate distance: (CGFloat) toValue duration: (CGFloat) duration;
 + (void) postTrackedTiming: (NSTimeInterval) timing withCategory: (NSString*) category andName: (NSString*) name;
++ (void) postTrackedTiming: (NSTimeInterval) timing withCategory: (NSString*) category andName: (NSString*) name andLabel: (NSString*) label;
 + (void) postAnalyticsEventWithCategory: (NSString*) category andAction: (NSString*) action andLabel: (NSString*) label;
 + (void) postAnalyticsEventWithCategory: (NSString*) category andAction: (NSString*) action andLabel: (NSString*) label andValue: (NSNumber*) value;
 + (NSString*) localInstallationId;

--- a/Ceaseless/AppUtils.h
+++ b/Ceaseless/AppUtils.h
@@ -28,4 +28,5 @@ blue:((float)(rgbValue & 0xFF))/255.0 alpha:a]
 + (void) postTrackedTiming: (NSTimeInterval) timing withCategory: (NSString*) category andName: (NSString*) name;
 + (void) postAnalyticsEventWithCategory: (NSString*) category andAction: (NSString*) action andLabel: (NSString*) label;
 + (void) postAnalyticsEventWithCategory: (NSString*) category andAction: (NSString*) action andLabel: (NSString*) label andValue: (NSNumber*) value;
++ (NSString*) localInstallationId;
 @end

--- a/Ceaseless/AppUtils.m
+++ b/Ceaseless/AppUtils.m
@@ -187,4 +187,17 @@
                                                            value:value] build]];    // Event value
     }
 }
+
++ (NSString*) localInstallationId {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    if (![defaults objectForKey:kLocalInstallationId]) {
+        NSUUID  *UUID = [NSUUID UUID];
+        NSString *localInstallationId = [UUID UUIDString];
+        [defaults setObject:localInstallationId forKey:kLocalInstallationId];
+        [defaults synchronize];
+        return localInstallationId;
+    } else {
+        return [defaults objectForKey:kLocalInstallationId];
+    }
+}
 @end

--- a/Ceaseless/CeaselessLocalContacts.h
+++ b/Ceaseless/CeaselessLocalContacts.h
@@ -37,6 +37,8 @@
 - (PersonIdentifier *) createCeaselessContactFromABRecord: (ABRecordRef) rawPerson;
 - (NSArray *) getAllActiveCeaselessContacts;
 - (NSInteger) numberOfActiveCeaselessContacts;
+- (NSInteger) numberOfFavoritedCeaselessContacts;
+- (NSInteger) numberOfRemovedCeaselessContacts;
 - (NSArray *) getAllCeaselessContacts;
 - (ABRecordRef) getRepresentativeABPersonForCeaselessContact: (PersonIdentifier*) person;
 - (UIImage *) getImageForPersonIdentifier: (PersonIdentifier *) person;

--- a/Ceaseless/CeaselessLocalContacts.h
+++ b/Ceaseless/CeaselessLocalContacts.h
@@ -23,6 +23,8 @@
 @property (nonatomic) ABAddressBookRef addressBook;
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundTask;
 @property (atomic) BOOL syncing;
+@property (atomic) BOOL internalAddressBookChange;
+@property (atomic) NSTimer *addressBookChangeNotificationTimer;
 
 + (id) sharedCeaselessLocalContacts;
 - (instancetype) initWithManagedObjectContext: (NSManagedObjectContext *) context andAddressBook: (ABAddressBookRef) addressBook;

--- a/Ceaseless/CeaselessLocalContacts.m
+++ b/Ceaseless/CeaselessLocalContacts.m
@@ -146,7 +146,13 @@ void externalAddressBookChangeCallback (ABAddressBookRef addressBook, CFDictiona
             NSDate *syncFinish = [NSDate date];
             NSTimeInterval executionTime = [syncFinish timeIntervalSinceDate:syncStart];
             NSLog(@"Address book sync executionTime = %f", executionTime);
-            [AppUtils postTrackedTiming:executionTime withCategory:@"resources" andName:@"address book sync timing"];
+            
+            NSString *localInstallationId = [AppUtils localInstallationId];
+            [AppUtils postTrackedTiming:executionTime withCategory:@"resources" andName:@"address book sync timing" andLabel:localInstallationId];
+            [AppUtils postAnalyticsEventWithCategory:@"address_book_sync" andAction:@"post_total_favorited_ceaseless_contacts" andLabel:localInstallationId andValue: [NSNumber numberWithInteger:clc.numberOfFavoritedCeaselessContacts]];
+            [AppUtils postAnalyticsEventWithCategory:@"address_book_sync" andAction:@"post_total_active_ceaseless_contacts" andLabel:localInstallationId andValue: [NSNumber numberWithInteger:clc.numberOfActiveCeaselessContacts]];
+            [AppUtils postAnalyticsEventWithCategory:@"address_book_sync" andAction:@"post_total_removed_ceaseless_contacts" andLabel:localInstallationId andValue: [NSNumber numberWithInteger:clc.numberOfRemovedCeaselessContacts]];
+            
             _syncing = NO;
 			[[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
 			self.backgroundTask = UIBackgroundTaskInvalid;

--- a/Ceaseless/CeaselessLocalContacts.m
+++ b/Ceaseless/CeaselessLocalContacts.m
@@ -294,12 +294,24 @@ void externalAddressBookChangeCallback (ABAddressBookRef addressBook, CFDictiona
 
 - (NSInteger) numberOfActiveCeaselessContacts {
     NSPredicate *filterRemovedContacts = [NSPredicate predicateWithFormat: @"removedDate = nil"];
+    return [self numberOfContactsForPredicate:filterRemovedContacts];
+}
+- (NSInteger) numberOfFavoritedCeaselessContacts {
+    NSPredicate *favoritedContacts = [NSPredicate predicateWithFormat: @"favoritedDate != nil"];
+    return [self numberOfContactsForPredicate:favoritedContacts];
+}
 
+- (NSInteger) numberOfRemovedCeaselessContacts {
+    NSPredicate *favoritedContacts = [NSPredicate predicateWithFormat: @"removedDate != nil"];
+    return [self numberOfContactsForPredicate:favoritedContacts];
+}
+
+- (NSInteger) numberOfContactsForPredicate: (NSPredicate *) predicate {
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
     NSEntityDescription *entity = [NSEntityDescription entityForName:@"PersonIdentifier"
                                               inManagedObjectContext:self.managedObjectContext];
     [fetchRequest setEntity:entity];
-    [fetchRequest setPredicate:filterRemovedContacts];
+    [fetchRequest setPredicate:predicate];
     NSError * error = nil;
     NSInteger peopleCount = [self.managedObjectContext countForFetchRequest:fetchRequest error:&error];
     

--- a/Ceaseless/CeaselessLocalContacts.m
+++ b/Ceaseless/CeaselessLocalContacts.m
@@ -105,7 +105,7 @@ void externalAddressBookChangeCallback (ABAddressBookRef addressBook, CFDictiona
     CeaselessLocalContacts *clc = (__bridge CeaselessLocalContacts *) context;
     // we need to use this timer because
     // the OS sends us multiple notifications when the address book changes
-    // this way we can pretend that any notifications that come within 3 seconds of one another
+    // this way we can pretend that any notifications that come within 4 seconds of one another
     // are actually one notification
     // and that means when we set internalAddressBookChange = NO in the selector
     // it will only happen one time instead of going into the method again and
@@ -113,7 +113,7 @@ void externalAddressBookChangeCallback (ABAddressBookRef addressBook, CFDictiona
     // http://stackoverflow.com/questions/10096480/abaddressbookregisterexternalchangecallback-called-several-times
     [clc.addressBookChangeNotificationTimer invalidate];
     clc.addressBookChangeNotificationTimer = nil;
-    clc.addressBookChangeNotificationTimer = [NSTimer scheduledTimerWithTimeInterval:3.0
+    clc.addressBookChangeNotificationTimer = [NSTimer scheduledTimerWithTimeInterval:4.0
                                                         target:clc
                                                       selector:@selector(handleAddressBookChanges)
                                                       userInfo:nil

--- a/Ceaseless/CeaselessLocalContacts.m
+++ b/Ceaseless/CeaselessLocalContacts.m
@@ -36,6 +36,7 @@
 - (instancetype) initWithManagedObjectContext: (NSManagedObjectContext *) context andAddressBook:(ABAddressBookRef)addressBook {
     self = [super init];
     if (self) {
+        self.internalAddressBookChange = NO;
         self.syncing = NO;
         self.backgroundTask = UIBackgroundTaskInvalid;
         self.addressBook = addressBook;
@@ -101,7 +102,30 @@
 
 #pragma mark - Keeping Ceaseless and the address book in sync
 void externalAddressBookChangeCallback (ABAddressBookRef addressBook, CFDictionaryRef info, void *context) {
-    [((__bridge CeaselessLocalContacts *) context) ensureCeaselessContactsSynced];
+    CeaselessLocalContacts *clc = (__bridge CeaselessLocalContacts *) context;
+    // we need to use this timer because
+    // the OS sends us multiple notifications when the address book changes
+    // this way we can pretend that any notifications that come within 3 seconds of one another
+    // are actually one notification
+    // and that means when we set internalAddressBookChange = NO in the selector
+    // it will only happen one time instead of going into the method again and
+    // doing a sync when we don't want it to (since the address book change came from within the app itself)
+    // http://stackoverflow.com/questions/10096480/abaddressbookregisterexternalchangecallback-called-several-times
+    [clc.addressBookChangeNotificationTimer invalidate];
+    clc.addressBookChangeNotificationTimer = nil;
+    clc.addressBookChangeNotificationTimer = [NSTimer scheduledTimerWithTimeInterval:3.0
+                                                        target:clc
+                                                      selector:@selector(handleAddressBookChanges)
+                                                      userInfo:nil
+                                                       repeats:NO];
+}
+
+- (void) handleAddressBookChanges {
+    if(self.internalAddressBookChange) {
+        self.internalAddressBookChange = NO;
+    } else {
+        [self ensureCeaselessContactsSynced];
+    }
 }
 
 - (void) ensureCeaselessContactsSynced {

--- a/Ceaseless/ContactsListsViewController.m
+++ b/Ceaseless/ContactsListsViewController.m
@@ -641,6 +641,10 @@ typedef NS_ENUM(NSInteger, ContactsListsPredicateScope)
                                                newPersonViewController.newPersonViewDelegate = self;
                                                UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:newPersonViewController];
                                                [self presentViewController:navController animated:YES completion:nil];
+                                               
+                                               CeaselessLocalContacts *clc = [CeaselessLocalContacts sharedCeaselessLocalContacts];
+                                               clc.internalAddressBookChange = YES;
+                                               
                                                NSLog(@"Add to Ceaseless");
                                            }];
     
@@ -663,6 +667,7 @@ typedef NS_ENUM(NSInteger, ContactsListsPredicateScope)
 
 #pragma mark - ABNewPersonViewControllerDelegate protocol conformance
 - (void)newPersonViewController:(ABNewPersonViewController *)newPersonView didCompleteWithNewPerson:(ABRecordRef)person {
+    CeaselessLocalContacts *ceaselessContacts = [CeaselessLocalContacts sharedCeaselessLocalContacts];
     if (person != NULL) {
         [self hideInstructions];
         ABRecordID abRecordID = ABRecordGetRecordID(person);
@@ -670,10 +675,10 @@ typedef NS_ENUM(NSInteger, ContactsListsPredicateScope)
         ABAddressBookRef addressBook = [AppUtils getAddressBookRef];
         
         ABRecordRef abPerson = ABAddressBookGetPersonWithRecordID(addressBook, abRecordID);
-        
-        CeaselessLocalContacts *ceaselessContacts = [CeaselessLocalContacts sharedCeaselessLocalContacts];
         [ceaselessContacts updateCeaselessContactFromABRecord: abPerson];
         CFRelease(addressBook);
+    } else {
+        ceaselessContacts.internalAddressBookChange = NO;
     }
     
     [newPersonView dismissViewControllerAnimated:YES completion:nil];

--- a/Ceaseless/NoteViewController.m
+++ b/Ceaseless/NoteViewController.m
@@ -564,7 +564,14 @@ NSString *const kPlaceHolderText = @"Enter note";
 	if (indexPath.row == self.filteredPeople.count) {
 		ABNewPersonViewController *newPersonViewController = [[ABNewPersonViewController alloc] init];
 		newPersonViewController.newPersonViewDelegate = self;
-
+        
+        
+        // mark that we're making an addressbook change in app
+        // so when the external change callback happens
+        // it won't kick off an unnecessary sync.
+        CeaselessLocalContacts *ceaselessContacts = [CeaselessLocalContacts sharedCeaselessLocalContacts];
+        ceaselessContacts.internalAddressBookChange = YES;
+        
 		UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:newPersonViewController];
 
 		[self presentViewController:navController animated:YES completion:NULL];
@@ -627,6 +634,9 @@ NSString *const kPlaceHolderText = @"Enter note";
 {
 	if (person != NULL) {
 		[self addABPersonToCeaseless: person];
+    } else {
+        CeaselessLocalContacts *ceaselessContacts = [CeaselessLocalContacts sharedCeaselessLocalContacts];
+        ceaselessContacts.internalAddressBookChange = NO;
     }
 
 	[newPersonView dismissViewControllerAnimated:YES completion:NULL];

--- a/Ceaseless/ProgressViewController.m
+++ b/Ceaseless/ProgressViewController.m
@@ -33,8 +33,9 @@ NSString *const kLastAnnouncementDate = @"localLastAnnouncementDate";
     
     self.progressView.progressLabel.text = [NSString stringWithFormat: @"%@ / %@ people", totalPeoplePrayedForThisCycle, totalPeople];
     
-    [AppUtils postAnalyticsEventWithCategory:@"progress_view" andAction:@"reached_last_card" andLabel:@"people_prayed_for_this_cycle" andValue: totalPeoplePrayedForThisCycle];
-    [AppUtils postAnalyticsEventWithCategory:@"progress_view" andAction:@"reached_last_card" andLabel:@"total_active_ceaseless_contacts" andValue: totalPeople];
+    NSString *localInstallationId = [AppUtils localInstallationId];
+    [AppUtils postAnalyticsEventWithCategory:@"progress_view" andAction:@"post_people_prayed_for_this_cycle" andLabel:localInstallationId andValue: totalPeoplePrayedForThisCycle];
+    [AppUtils postAnalyticsEventWithCategory:@"progress_view" andAction:@"post_total_active_ceaseless_contacts" andLabel:localInstallationId andValue: totalPeople];
     
     self.progressView.backgroundImageView.image = [AppUtils getDynamicBackgroundImage];
     [self.progressView.progressBar setProgress: progressPercentage animated:YES];

--- a/CeaselessTests/CeaselessTests.m
+++ b/CeaselessTests/CeaselessTests.m
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 #import "AppUtils.h"
+#import "CeaselessLocalContacts.h"
 
 @interface CeaselessTests : XCTestCase
 
@@ -51,6 +52,14 @@
 
     NSNumber *days = [AppUtils daysWithinEraFromDate:start toDate:end];
     XCTAssert([days isEqual: [NSNumber numberWithInt: 1]], @"Pass");
+}
+
+- (void) testAddressBookCounts {
+    CeaselessLocalContacts *clc = [CeaselessLocalContacts sharedCeaselessLocalContacts];
+    NSLog(@"Active: %@", [NSNumber numberWithInteger: clc.numberOfActiveCeaselessContacts]);
+    NSLog(@"Favorited: %@", [NSNumber numberWithInteger: clc.numberOfFavoritedCeaselessContacts]);
+    NSLog(@"Removed: %@", [NSNumber numberWithInteger: clc.numberOfRemovedCeaselessContacts]);
+    XCTAssert(clc.numberOfActiveCeaselessContacts > 0, @"Pass");
 }
 
 - (void)testPerformanceExample {


### PR DESCRIPTION
Before when a person is added in the People view, the Syncing... overlay appears and it takes awhile and is quite annoying. Now if a person is added from within the app, we already handle creating a ceaseless contact for it, so instead the external callback that listens for changes to the address book checks to see if it is an app-internal change to the address book and if so it does not do the syncing process.

We had to do something somewhat hacky--the OS sends multiple address book change notifications, so we had to smooth that over with a timer that runs the handler one time for all notifications within a 3 second window of each other. In testing it seemed sufficiently reliable.